### PR TITLE
Fix missing key id and add Texas pods

### DIFF
--- a/fakeauth/main.py
+++ b/fakeauth/main.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from base64 import b64decode
 import requests
 import json
+import uuid
 
 app = FastAPI()
 key = get_or_create_jwk()
@@ -103,6 +104,6 @@ def generate_sub_token(aud):
         "iat": int(datetime.utcnow().timestamp()),
         "exp": int((datetime.utcnow() + timedelta(days=1)).timestamp()),
     }
-    token = jwt.JWT(header={"alg": "RS256", "type": "JWT"}, claims=claims)
+    token = jwt.JWT(header={"alg": "RS256", "type": "JWT", "kid": str(key.kid)}, claims=claims)
     token.make_signed_token(key)
     return token.serialize()

--- a/some_app/utils/tokenx.py
+++ b/some_app/utils/tokenx.py
@@ -22,7 +22,7 @@ def create_client_assertion():
         "iat": int(datetime.utcnow().timestamp()),
         "exp": int((datetime.utcnow() + timedelta(seconds=119)).timestamp()),
     }
-    token = jwt.JWT(header={"alg": "RS256", "typ": "JWT"}, claims=claims)
+    token = jwt.JWT(header={"alg": "RS256", "typ": "JWT", "kid": client_jwks.kid}, claims=claims)
     token.make_signed_token(client_jwks)
     return token.serialize()
 

--- a/tokendings-conf/fake_auth.yml
+++ b/tokendings-conf/fake_auth.yml
@@ -11,8 +11,6 @@ spec:
     outbound:
       rules:
         - application: tokendings
-      external:
-        - host: login.microsoftonline.com
     inbound:
       rules:
         - application: tokendings

--- a/tokendings-conf/some_app.yml
+++ b/tokendings-conf/some_app.yml
@@ -16,6 +16,7 @@ spec:
     inbound:
       rules:
         - application: tokendings
+        - application: test-app
   env:
     - name: CLUSTER_NAME
       valueFrom:
@@ -30,7 +31,7 @@ spec:
     - name: FAKEAUTH_LOGIN_URL
       value: http://fake-auth:6348/fake_auth
     - name: FAKEAUTH_JWKS_URI
-      value: http://fake-auth:6348/discovery/v2.0/keys
+      value: http://fake-auth:6348/discovery/v2.0/keys/
     - name: TOKEN_X_PRIVATE_JWK
       valueFrom:
         secretKeyRef:
@@ -55,7 +56,68 @@ spec:
           key: TOKEN_X_JWKS_URI
           name: jwker-some-app
           optional: false
-
+--- 
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: texas-some-app
+  namespace: obo
+spec:
+  image: ghcr.io/nais/texas:latest
+  port: 3000
+  env:
+    - name: DOWNSTREAM_APP_NAME
+      value: some-app
+    - name: DOWNSTREAM_APP_NAMESPACE
+      value: obo
+    - name: DOWNSTREAM_APP_CLUSTER
+      value: kind-skiperator
+    - name: MASKINPORTEN_ENABLED
+      value: "false"
+    - name: AZURE_ENABLED
+      value: "false"
+    - name: IDPORTEN_ENABLED
+      value: "false"
+    - name: TOKEN_X_ENABLED
+      value: "true"
+    - name: TOKEN_X_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          key: TOKEN_X_CLIENT_ID
+          name: jwker-some-app
+          optional: false
+    - name: TOKEN_X_TOKEN_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          key: TOKEN_X_TOKEN_ENDPOINT
+          name: jwker-some-app
+          optional: false
+    - name: TOKEN_X_JWKS_URI
+      valueFrom:
+        secretKeyRef:
+          key: TOKEN_X_JWKS_URI
+          name: jwker-some-app
+          optional: false
+    - name: TOKEN_X_PRIVATE_JWK
+      valueFrom:
+        secretKeyRef:
+          key: TOKEN_X_PRIVATE_JWK
+          name: jwker-some-app
+          optional: false
+    - name: TOKEN_X_ISSUER
+      value: http://tokendings:7456
+    - name: NAIS_POD_NAME
+      value: texas-7986845877-m2d4l
+  replicas: 1
+  accessPolicy:
+    outbound:
+      rules:
+        - application: fake-auth
+        - application: tokendings
+        - application: test-app
+    inbound:
+      rules:
+        - application: some-app
 ---
 apiVersion: nais.io/v1
 kind: Jwker

--- a/tokendings-conf/some_app.yml
+++ b/tokendings-conf/some_app.yml
@@ -13,6 +13,7 @@ spec:
         - application: tokendings
         - application: fake-auth
         - application: test-app
+        - application: texas-some-app
     inbound:
       rules:
         - application: tokendings
@@ -66,6 +67,8 @@ spec:
   image: ghcr.io/nais/texas:latest
   port: 3000
   env:
+    - name: BIND_ADDRESS
+      value: 0.0.0.0:3000
     - name: DOWNSTREAM_APP_NAME
       value: some-app
     - name: DOWNSTREAM_APP_NAMESPACE

--- a/tokendings-conf/test_app.yml
+++ b/tokendings-conf/test_app.yml
@@ -12,6 +12,7 @@ spec:
       rules:
         - application: tokendings
         - application: fake-auth
+        - application: texas-test-app
     inbound:
       rules:
         - application: tokendings
@@ -67,6 +68,8 @@ spec:
   image: ghcr.io/nais/texas:latest
   port: 3000
   env:
+    - name: BIND_ADDRESS
+      value: 0.0.0.0:3000
     - name: DOWNSTREAM_APP_NAME
       value: test-app
     - name: DOWNSTREAM_APP_NAMESPACE

--- a/tokendings-conf/test_app.yml
+++ b/tokendings-conf/test_app.yml
@@ -58,6 +58,67 @@ spec:
           optional: false
 
 ---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: texas-test-app
+  namespace: obo
+spec:
+  image: ghcr.io/nais/texas:latest
+  port: 3000
+  env:
+    - name: DOWNSTREAM_APP_NAME
+      value: test-app
+    - name: DOWNSTREAM_APP_NAMESPACE
+      value: obo
+    - name: DOWNSTREAM_APP_CLUSTER
+      value: kind-skiperator
+    - name: MASKINPORTEN_ENABLED
+      value: "false"
+    - name: AZURE_ENABLED
+      value: "false"
+    - name: IDPORTEN_ENABLED
+      value: "false"
+    - name: TOKEN_X_ENABLED
+      value: "true"
+    - name: TOKEN_X_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          key: TOKEN_X_CLIENT_ID
+          name: jwker-test-app
+          optional: false
+    - name: TOKEN_X_TOKEN_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          key: TOKEN_X_TOKEN_ENDPOINT
+          name: jwker-test-app
+          optional: false
+    - name: TOKEN_X_JWKS_URI
+      valueFrom:
+        secretKeyRef:
+          key: TOKEN_X_JWKS_URI
+          name: jwker-test-app
+          optional: false
+    - name: TOKEN_X_PRIVATE_JWK
+      valueFrom:
+        secretKeyRef:
+          key: TOKEN_X_PRIVATE_JWK
+          name: jwker-test-app
+          optional: false
+    - name: TOKEN_X_ISSUER
+      value: http://tokendings:7456
+    - name: NAIS_POD_NAME
+      value: texas-7986845877-m2d4a
+  replicas: 1
+  accessPolicy:
+    outbound:
+      rules:
+        - application: fake-auth
+        - application: tokendings
+    inbound:
+      rules:
+        - application: test-app
+---
 apiVersion: nais.io/v1
 kind: Jwker
 metadata:

--- a/tokendings-conf/tokendings.yml
+++ b/tokendings-conf/tokendings.yml
@@ -45,3 +45,5 @@ spec:
         - application: jwker
         - application: some-app
         - application: test-app
+        - application: texas-some-app
+        - application: texas-test-app


### PR DESCRIPTION
## Fix missing key ids as Texas requires key id when parsing tokens 🐛 
Simply add uuid to the kid header
## Add Texas pods for some app and test app ✨ 
Since skiperator does not expose config for adding sidecars, a Texas pod is created for some-app and test-app. Since only some app can talk to test app, the test app Texas pod is ment for introspect tokens from some app and the Texas some app is ment for exchange token for talking to test-app